### PR TITLE
Save state on event, not just on assignment. 

### DIFF
--- a/GameBuilderBot/Runners/RollEventRunner.cs
+++ b/GameBuilderBot/Runners/RollEventRunner.cs
@@ -8,9 +8,11 @@ namespace GameBuilderBot.Runners
     public class RollEventRunner : CommandRunner
     {
         protected string[] _variables;
+        protected ExportService _exportService;
 
-        public RollEventRunner(GameHandlingService gameHandler) : base(gameHandler)
+        public RollEventRunner(GameHandlingService gameHandler, ExportService exportService) : base(gameHandler)
         {
+            _exportService = exportService;
         }
 
         public string RollEvent(string[] objects, SocketCommandContext discordContext)
@@ -32,6 +34,7 @@ namespace GameBuilderBot.Runners
                 GameEvent theEvent = definition.GameEventMap[gameEventAsString];
 
                 response = $"Outcome of {gameEventAsString} event:\n{theEvent.GetResponseForEventRoll(definition, state, 0)}";
+                _exportService.ExportGameState(state, discordContext);
             }
             else
             {

--- a/GameBuilderBot/Services/ResponseService.cs
+++ b/GameBuilderBot/Services/ResponseService.cs
@@ -40,7 +40,7 @@ namespace GameBuilderBot.Services
             // Registration order of runners dictates order of output in the help message
             _startGameRunner = RegisterRunner(new StartGameRunner(_gameService));
             _endGameRunner = RegisterRunner(new EndGameRunner(_gameService));
-            _rollEventRunner = RegisterRunner(new RollEventRunner(_gameService));
+            _rollEventRunner = RegisterRunner(new RollEventRunner(_gameService, _exportService));
             _deleteVariableRunner = RegisterRunner(new DeleteVariableRunner(_gameService, _exportService));
             _prettyPrintVariableRunner = RegisterRunner(new PrettyPrintVariableRunner(_gameService));
             _setValueRunner = RegisterRunner(new SetValueRunner(_gameService, _exportService));


### PR DESCRIPTION
Previously, variables set as a result of an event did not persist until the next time a user explicitly assigned a value to a variable. If the user never assigned a value to a variable, the event variables were lost.